### PR TITLE
issue 8: image dnd 구현

### DIFF
--- a/src/components/ImageDnDWrapper.tsx
+++ b/src/components/ImageDnDWrapper.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import useMarkdown from '@hooks/contexts/useMarkdown';
+import styled from 'styled-components';
 
 interface ImageDnDWrapperProps {
   children: React.ReactNode;
@@ -27,14 +28,18 @@ const ImageDnDWrapper = ({ children }: ImageDnDWrapperProps) => {
     const imgMarkdownURL = `![](${URL.createObjectURL(e.dataTransfer.files[0])})`;
 
     setMarkdownText((prev) => prev + imgMarkdownURL);
-    setImageUpload((prev) => !prev);
+    setImageUpload(false);
   };
 
   return (
-    <div onDragEnter={handleImageDragEnter} onDragLeave={handleImageDragLeave} onDrop={handleImageDrop}>
+    <Wrapper onDragEnter={handleImageDragEnter} onDragLeave={handleImageDragLeave} onDrop={handleImageDrop}>
       {children}
-    </div>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div`
+  width: 100%;
+`;
 
 export default ImageDnDWrapper;

--- a/src/components/ImageDnDWrapper.tsx
+++ b/src/components/ImageDnDWrapper.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import useMarkdown from '@hooks/contexts/useMarkdown';
+
+interface ImageDnDWrapperProps {
+  children: React.ReactNode;
+}
+
+const ImageDnDWrapper = ({ children }: ImageDnDWrapperProps) => {
+  const [imageUpload, setImageUpload] = useState(false);
+  const { setMarkdownText } = useMarkdown();
+
+  const handleImageDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+
+    setImageUpload((prev) => !prev);
+  };
+
+  const handleImageDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+
+    setImageUpload((prev) => !prev);
+  };
+
+  const handleImageDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+
+    const imgMarkdownURL = `![](${URL.createObjectURL(e.dataTransfer.files[0])})`;
+
+    setMarkdownText((prev) => prev + imgMarkdownURL);
+    setImageUpload((prev) => !prev);
+  };
+
+  return (
+    <div onDragEnter={handleImageDragEnter} onDragLeave={handleImageDragLeave} onDrop={handleImageDrop}>
+      {children}
+    </div>
+  );
+};
+
+export default ImageDnDWrapper;

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -23,12 +23,7 @@ const ImageUpload = () => {
 
   return (
     <div>
-      <input
-        type='file'
-        ref={imageUploadRef}
-        onChange={handleChangeImageUpload}
-        // style={{ display: "none" }}
-      />
+      <input type='file' ref={imageUploadRef} onChange={handleChangeImageUpload} style={{ display: 'none' }} />
 
       <button type='button' onClick={handleClickImageUpload}>
         upload

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -1,3 +1,4 @@
+import styled from 'styled-components';
 import useMarkdown from '../hooks/contexts/useMarkdown';
 
 const MarkdownEditor = () => {
@@ -7,7 +8,12 @@ const MarkdownEditor = () => {
     setMarkdownText(e.currentTarget.value);
   };
 
-  return <textarea onChange={handleEditorChage} value={markdownText} name='temp' id='temp' cols={30} rows={10} />;
+  return <Textarea onChange={handleEditorChage} value={markdownText} cols={30} rows={30} placeholder='Description' />;
 };
+
+const Textarea = styled.textarea`
+  width: 100%;
+  height: 100%;
+`;
 
 export default MarkdownEditor;

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -3,11 +3,11 @@ import useMarkdown from '../hooks/contexts/useMarkdown';
 const MarkdownEditor = () => {
   const { markdownText, setMarkdownText } = useMarkdown();
 
-  const editorChage = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleEditorChage = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setMarkdownText(e.currentTarget.value);
   };
 
-  return <textarea onChange={editorChage} value={markdownText} name='temp' id='temp' cols={30} rows={10} />;
+  return <textarea onChange={handleEditorChage} value={markdownText} name='temp' id='temp' cols={30} rows={10} />;
 };
 
 export default MarkdownEditor;

--- a/src/pages/write/Write.tsx
+++ b/src/pages/write/Write.tsx
@@ -1,3 +1,4 @@
+import ImageDnDWrapper from '@components/ImageDnDWrapper';
 import ImageUpload from '@components/ImageUpload';
 import MarkdownEditor from '@components/MarkdownEditor';
 import Result from '@components/Result';
@@ -11,7 +12,9 @@ const Write = () => {
   return (
     <MarkdownContext.Provider value={contextValue}>
       <ImageUpload />
-      <MarkdownEditor />
+      <ImageDnDWrapper>
+        <MarkdownEditor />
+      </ImageDnDWrapper>
       <Result />
     </MarkdownContext.Provider>
   );


### PR DESCRIPTION
Write 페이지에서 이미지 dnd 구현했습니다.

dragEnter, dragLeave, drop 활용하면서 Wrapper로 editor를 감싸는 형식으로 코드를 작성했습니다.

스타일 관련해서는 좀 더 적용해보려 했는데 어떻게 설계하는지에 따라 다른 코드들이 많이 달라질 것 같아서 우선 크기만 적용했습니다.

드래그 상태에서 어떻게 스타일을 주는게 좋을지 이야기해봐야 할 것 같습니다.

close #8 
